### PR TITLE
Fixed issue with AWS service credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ all the parameters it needs or your infrastructure can be created directly yet s
 
 ## Latest Update
 
+### v2.0.2
+
+#### Changes
+
+- When creating the client configuration, `cf-utils` now checks whether `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set in the environment. If they are, those credentials are used. Otherwise, the credentials are sourced from the default credentials provider chain. This resolves an issue in environments where AWS keys are set, but an AWS profile is also configured without corresponding credentials.
+
 ### v2.0.1
 
 #### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-utils",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Unlicense",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Tools and utilities to help build task runner style deployment pipelines with AWS CloudFormation",
   "author": "David Boland",
   "license": "Unlicense",


### PR DESCRIPTION
- Bumped version: `v2.0.2`
- When creating the client configuration, `cf-utils` now checks whether `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set in the environment. If they are, those credentials are used. Otherwise, the credentials are sourced from the default credentials provider chain. This resolves an issue in environments where AWS keys are set, but an AWS profile is also configured without corresponding credentials.