### PR TITLE
S3 bucket notification configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ all the parameters it needs or your infrastructure can be created directly yet s
 
 ## Latest Update
 
+### v2.0.3
+
+#### Changes
+
+- Added putBucketNotificationConfiguration to s3 (this is required in stack tasks, otherwise you get a circular dependency in cloudformation. This is the aws recommended approach to this problem)
+- Fixed an issue where if there were no updates to be made to a stack, the stack info would not be returned
+
 ### v2.0.2
 
 #### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-utils",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Unlicense",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tools and utilities to help build task runner style deployment pipelines with AWS CloudFormation",
   "author": "David Boland",
   "license": "Unlicense",

--- a/src/cloudFormation.js
+++ b/src/cloudFormation.js
@@ -178,7 +178,6 @@ async function updateStack(params) {
   } catch (err) {
     if (err.toString().indexOf('No updates are to be performed') >= 0) {
       config.logger.info('There are no changes to apply, continuing....');
-      return;
     } else {
       throw err;
     }

--- a/src/s3.js
+++ b/src/s3.js
@@ -11,7 +11,8 @@ const {
   ListObjectVersionsCommand,
   DeleteObjectsCommand,
   GetBucketVersioningCommand,
-  PutObjectCommand
+  PutObjectCommand,
+  PutBucketNotificationConfigurationCommand
 } = require('@aws-sdk/client-s3');
 
 /**
@@ -261,6 +262,18 @@ async function uploadDirectoryAsZipFile(bucketName, key, source, dest, name) {
   return fullPath;
 }
 
+/**
+ * Add a notification configuration to the specified bucket
+ * @param params AWS bucket notification configuration params
+ * @returns {Promise}
+ */
+async function putBucketNotificationConfiguration(params) {
+  const s3 = new S3Client(config.AWS.clientConfig);
+  const res = await s3.send(new PutBucketNotificationConfigurationCommand(params));
+  config.logger.info('Successfully added notification configuration to s3://', params.Bucket);
+  return res
+}
+
 
 module.exports = {
   putS3Object,
@@ -270,5 +283,6 @@ module.exports = {
   deleteVersionedObjects,
   emptyBucket,
   uploadDirectory,
-  uploadDirectoryAsZipFile
+  uploadDirectoryAsZipFile,
+  putBucketNotificationConfiguration
 };

--- a/test/s3.spec.js
+++ b/test/s3.spec.js
@@ -12,7 +12,8 @@ const {
   GetBucketVersioningCommand,
   PutObjectCommand,
   CreateMultipartUploadCommand, // Used for lib-storage/Upload
-  UploadPartCommand // Used for lib-storage/Upload
+  UploadPartCommand, // Used for lib-storage/Upload
+  PutBucketNotificationConfigurationCommand
 } = require('@aws-sdk/client-s3');
 
 // Rewire
@@ -349,6 +350,44 @@ describe("src/s3", () => {
     s3Mock.on(UploadPartCommand).resolves({ ETag: '1' });
 
     return expect(s3.uploadDirectoryAsZipFile(bucket, key, dir, dir, key)).to.eventually.deep.equal(`${mockFs.ONLY_FILES_DIR}/${key}`);
+  });
+
+  // putBucketNotificationConfiguration
+  it("puts bucket notification configuration", async () => {
+    const params = {
+      Bucket: "bucket",
+      NotificationConfiguration: {
+        EventBridgeConfiguration: {},
+        LambdaFunctionConfigurations: [],
+        QueueConfigurations: [],
+        TopicConfigurations: []
+      }
+    };
+
+    s3Mock.on(PutBucketNotificationConfigurationCommand).callsFake(input => {
+      expect(input).to.eql(params);
+      return {
+        '$metadata': {
+          httpStatusCode: 200,
+          requestId: 'requestId',
+          extendedRequestId: 'extendedRequestId',
+          cfId: undefined,
+          attempts: 1,
+          totalRetryDelay: 0
+        }
+      };
+    });
+
+    return expect(s3.putBucketNotificationConfiguration(params)).to.eventually.deep.equal({
+      '$metadata': {
+          httpStatusCode: 200,
+          requestId: 'requestId',
+          extendedRequestId: 'extendedRequestId',
+          cfId: undefined,
+          attempts: 1,
+          totalRetryDelay: 0
+        }
+    });
   });
 
 });


### PR DESCRIPTION
- Added putBucketNotificationConfiguration to s3 (this is required in stack tasks, otherwise you get a circular dependency in cloudformation. This is the aws recommended approach to this problem)
- Fixed an issue where if there were no updates to be made to a stack, the stack info would not be returned